### PR TITLE
Update help command text formatting in i18n files

### DIFF
--- a/src/app/i18n/en.json
+++ b/src/app/i18n/en.json
@@ -23,7 +23,7 @@
   },
   "commands": {
     "cleared": "Terminal cleared. Memory and mood scores reset.",
-    "help": "Available commands:\\n/clear - Clear terminal\\n/help - Show this help\\n/repo - Visit GitHub repository\\n/privacy - View privacy policy",
+    "help": "Available commands:\n/clear - Clear terminal\n/help - Show this help\n/privacy - View privacy policy\n/repo - Visit GitHub repository",
     "repo": "Opening GitHub repository: https://github.com/asyntes/tomie",
     "unknown": "ERROR: Unknown command '{command}'. Type /help for available commands."
   },

--- a/src/app/i18n/it.json
+++ b/src/app/i18n/it.json
@@ -23,7 +23,7 @@
   },
   "commands": {
     "cleared": "Terminale pulito. Memoria e punteggi umore reimpostati.",
-    "help": "Comandi disponibili:\\n/clear - Pulisce il terminale\\n/help - Mostra questo aiuto\\n/repo - Visita repository GitHub\\n/privacy - Visualizza informativa privacy",
+    "help": "Comandi disponibili:\n/clear - Pulisce il terminale\n/help - Mostra questo aiuto\n/privacy - Visualizza informativa privacy\n/repo - Visita repository GitHub",
     "repo": "Apertura repository GitHub: https://github.com/asyntes/tomie",
     "unknown": "ERRORE: Comando sconosciuto '{command}'. Digita /help per i comandi disponibili."
   },


### PR DESCRIPTION
Replaces escaped newlines with actual newlines in the help command text for both English and Italian translations, and reorders the command list for consistency.