### PR TITLE
Update ESLint ignores; clean up test/eval imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,14 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [
+      "**/__tests__/**",
+      "**/*.test.ts",
+      "**/*.eval.ts",
+      "vitest.eval.config.ts",
+    ],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/src/app/core/__tests__/moodStateMachine.test.ts
+++ b/src/app/core/__tests__/moodStateMachine.test.ts
@@ -37,7 +37,7 @@ describe('moodStateMachine', () => {
   });
 
   it('transitions to angry on second insult with neutral model tag', () => {
-    let state = commitTurn(createInitialMoodState(), 'neutral', 'vaffanculo').newState;
+    const state = commitTurn(createInitialMoodState(), 'neutral', 'vaffanculo').newState;
     const commit = commitTurn(state, 'neutral', 'fottiti');
     expect(commit.shouldChangeMood).toBe(true);
     expect(commit.newState.currentMood).toBe('angry');

--- a/src/app/evals/moodTransitions.eval.ts
+++ b/src/app/evals/moodTransitions.eval.ts
@@ -1,13 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { Mood } from '../types/mood';
 import { createInitialMoodState } from '../core/moodStateMachine';
-import {
-    runLlmScript,
-    runSimulatedScript,
-    runTomieTurn,
-    formatState,
-} from './evalHelpers';
-import { judgeWithLlm, loadEnvLocal } from './evalJudge';
+import { runLlmScript, runSimulatedScript, runTomieTurn } from './evalHelpers';
+import { loadEnvLocal } from './evalJudge';
 
 const RUN = process.env.RUN_LLM_EVALS === '1';
 

--- a/src/app/evals/moodTriggerTrace.eval.ts
+++ b/src/app/evals/moodTriggerTrace.eval.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { Mood } from '../types/mood';
 import { createInitialMoodState } from '../core/moodStateMachine';
 import { loadEnvLocal } from './evalJudge';
 


### PR DESCRIPTION
Add ESLint ignore patterns for __tests__, *.test.ts, *.eval.ts, and vitest.eval.config.ts to reduce lint noise. Also make a small test change (let -> const) in moodStateMachine.test.ts and remove unused imports from moodTransitions.eval.ts and moodTriggerTrace.eval.ts to clean up warnings and improve code clarity.