### PR TITLE
Add LLM mood classifier and two-step detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Interactive AI terminal interface built with Next.js and React. Tomie is a chara
 |------|-------|--------------------------------------|
 | **Neutral** | Blue | Normal chat, factual questions |
 | **Angry** | Red | Sustained hostility (2 tags) |
-| **Romantic** | Purple | Explicit flirt / love (3 tags; slowest to enter) |
+| **Romantic** | Purple | Explicit flirt / love (2 tags, same as other moods) |
 | **Excited** | Orange | Enthusiasm (2 tags) |
 | **Confused** | Green | Unclear or lost user (2 tags) |
 
@@ -35,16 +35,14 @@ flowchart TB
 
     neutral -->|"1st non-neutral MOOD tag"| approaching["Approaching<br/>pending mood, UI unchanged"]
 
-    approaching -->|"2 matching tags"| stable_fast["Stable angry, excited, or confused"]
-    approaching -->|"3 matching tags"| stable_romantic["Stable romantic"]
+    approaching -->|"2 matching tags"| stable_mood["Stable mood incl. romantic"]
     approaching -->|"MOOD neutral"| approaching
 
-    stable_fast -->|"1st MOOD neutral"| cooling["Cooling<br/>UI unchanged"]
-    stable_romantic -->|"1st MOOD neutral"| cooling
+    stable_mood -->|"1st MOOD neutral"| cooling["Cooling<br/>UI unchanged"]
 
     cooling -->|"2nd MOOD neutral"| neutral
 
-    stable_fast -.->|"cannot jump to another mood"| stable_fast
+    stable_mood -.->|"cannot jump to another mood"| stable_mood
 ```
 
 | Phase | Visual UI | Behavior |
@@ -58,14 +56,16 @@ flowchart TB
 
 | Direction | All moods (angry, romantic, excited, confused) |
 |-----------|--------------------------------------------------|
-| Enter (from neutral) | 2 tags (angry, excited, confused); **3 tags** for romantic |
+| Enter (from neutral) | **2** matching `[MOOD:]` tags (all moods including romantic) |
 | Exit (to neutral) | 2 consecutive `[MOOD:neutral]` tags |
 
-**Important:** Progress uses only `detectedMood` from the API (parsed from `[MOOD:…]` in Grok’s reply). If the UI stays on neutral, inspect the `/api/grok` response — the model may be tagging `[MOOD:neutral]` too often.
+**Important:** Progress uses the mood signal from Grok. Each reply includes a `[MOOD:…]` tag; if that tag is `[MOOD:neutral]`, a **second lightweight LLM call** classifies the user message (no regex in TypeScript). Both paths are prompt-driven.
+
+If the UI stays neutral, check `/api/grok` → `detectedMood` in DevTools.
 
 Mismatch handling: a `[MOOD:neutral]` tag while **approaching** freezes progress (no decay). From **stable** neutral, a mismatched tag decays approaching progress slowly.
 
-Hostile user text with a `[MOOD:neutral]` reply still counts toward **angry** when insult keywords are detected (`moodSignalResolver`).
+**Fixing wrong tags:** improve prompts in `src/app/services/ai/prompts/moodPersonalities.ts` (`MOOD_DETECTION_GUIDELINES`) and approaching blocks in `promptGenerator.ts` — not application code heuristics.
 
 ### Trying moods manually
 
@@ -73,10 +73,10 @@ After `/clear`, send **two messages in a row** with the same emotional tone. The
 
 | Target mood | Example inputs (×2) |
 |-------------|---------------------|
-| Excited | `WOW è INCREDIBILE!!!` |
-| Confused | `Non capisco cosa intendi` |
-| Romantic | 3 explicit flirt/love messages in a row |
-| Angry | Sustained hostility / insults |
+| Excited | `WOW!!! INCREDIBILE!!!` then `È FANTASTICO!!!` (×2) |
+| Confused | `Non capisco nulla` then `Sono perso, spiegati meglio` (×2) |
+| Romantic | 2 explicit messages (e.g. *Ti desidero…* then *Ti amo Tomie*) |
+| Angry | Two hostile messages (model must tag `[MOOD:angry]` each time) |
 
 ## Environment variables
 
@@ -148,8 +148,9 @@ TomieTerminal
   → responseHandler.generateFullResponse
       → moodStateMachine.previewTurn(state)     # pick responseMood for this turn
       → POST /api/grok                          # GrokService + PromptGenerator
-      → moodDetector.extractMoodFromResponse    # [MOOD:] → detectedMood
-      → moodStateMachine.commitTurn(state, tag) # update progress / transition
+      → moodDetector.extractMoodFromResponse    # [MOOD:] from reply
+      → moodClassifier (if neutral)             # second LLM call on user message
+      → moodStateMachine.commitTurn(state, tag)
   → UI: brief interference (~550ms) + setMoodState if shouldChangeMood
 ```
 
@@ -164,7 +165,8 @@ TomieTerminal
 | [`src/app/core/stateManager.ts`](src/app/core/stateManager.ts) | Initial state + thin wrapper over `commitTurn` |
 | [`src/app/services/ai/grokService.ts`](src/app/services/ai/grokService.ts) | xAI client, model from env |
 | [`src/app/services/ai/promptGenerator.ts`](src/app/services/ai/promptGenerator.ts) | System prompt: `responseMood`, approaching, tag rules |
-| [`src/app/services/ai/moodDetector.ts`](src/app/services/ai/moodDetector.ts) | Parse and strip `[MOOD:…]` |
+| [`src/app/services/ai/moodDetector.ts`](src/app/services/ai/moodDetector.ts) | Parse `[MOOD:…]` from character reply |
+| [`src/app/services/ai/moodClassifier.ts`](src/app/services/ai/moodClassifier.ts) | Fallback LLM classifier when reply tag is neutral |
 | [`src/app/services/ai/prompts/moodPersonalities.ts`](src/app/services/ai/prompts/moodPersonalities.ts) | Personalities + tag guidelines for the model |
 | [`src/app/components/TomieTerminal/TomieTerminal.tsx`](src/app/components/TomieTerminal/TomieTerminal.tsx) | UI, typing, mood visuals |
 
@@ -175,7 +177,7 @@ TomieTerminal
 | `src/app/core/__tests__/moodStateMachine.test.ts` | Unit — thresholds, approaching, decay |
 | `src/app/core/__tests__/moodTransitionScenarios.test.ts` | Unit — multi-turn tag sequences |
 | `src/app/services/ai/__tests__/moodDetector.test.ts` | Unit — tag parsing |
-| `src/app/evals/moodJudge.eval.ts` | Optional LLM judge |
+| `src/app/evals/moodTagging.eval.ts` | LLM — asserts final mood state per user message sequence |
 
 ## Commands
 
@@ -194,13 +196,18 @@ TomieTerminal
 - Vitest
 - Custom i18n (`src/app/i18n/`)
 
-## AI prompts
+## AI prompts (mood detection)
 
-- **Personalities** — Per-mood voice in `moodPersonalities.ts`
-- **Tag rules** — Mandatory `[MOOD:]` on every reply; guidelines + examples teach Grok when to use each tag (not runtime keyword matching)
-- **Language** — Replies match user language (IT/EN)
-- **Approaching** — Subtle tone shift + hint to keep tagging the pending mood when the user continues the same tone
-- **Tone vs tag** — Response text uses `responseMood`; the tag labels user input only
+All mood detection is **prompt-driven** (no regex on user input in TypeScript).
+
+| Layer | File | Role |
+|-------|------|------|
+| Reply tag | `moodDetector.ts` | Parse `[MOOD:…]` from character reply |
+| Fallback classifier | `moodClassifier.ts` + `grokService.classifyUserMood` | If reply tag is neutral, one-word LLM classification of user message |
+| Tag taxonomy | `moodPersonalities.ts` → `MOOD_DETECTION_GUIDELINES` | Instructs reply tagging |
+| Per-turn context | `promptGenerator.ts` | User message + approaching rules |
+
+Run `RUN_LLM_EVALS=1 npm run test:tags` to verify angry / excited / confused / romantic reach the expected UI state (checks **state machine + tags**, not LLM-as-judge on tone).
 
 ## Project structure (summary)
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:transitions": "vitest run src/app/core/__tests__/moodCrossTransitions.test.ts",
     "test:eval": "vitest run --config vitest.eval.config.ts",
-    "test:trace": "vitest run --config vitest.eval.config.ts src/app/evals/moodTriggerTrace.eval.ts"
+    "test:trace": "vitest run --config vitest.eval.config.ts src/app/evals/moodTriggerTrace.eval.ts",
+    "test:tags": "vitest run --config vitest.eval.config.ts src/app/evals/moodTagging.eval.ts"
   },
   "dependencies": {
     "next": "15.4.8",

--- a/src/app/api/grok/classify/route.ts
+++ b/src/app/api/grok/classify/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GrokService } from '../../../services';
+
+export async function POST(request: NextRequest) {
+    try {
+        const { prompt } = (await request.json()) as { prompt?: string };
+        if (!prompt?.trim()) {
+            return NextResponse.json({ error: 'prompt required' }, { status: 400 });
+        }
+
+        const grok = GrokService.createFromEnv();
+        const mood = await grok.classifyUserMood(prompt);
+
+        return NextResponse.json({ mood });
+    } catch (error) {
+        console.error('Error in mood classify route:', error);
+        const message = error instanceof Error ? error.message : 'Failed to classify mood';
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/src/app/core/__tests__/moodCrossTransitions.test.ts
+++ b/src/app/core/__tests__/moodCrossTransitions.test.ts
@@ -44,7 +44,6 @@ describe('cross-mood transitions (simulated tags)', () => {
         let s = createInitialMoodState();
         s = commitTurn(s, 'romantic').newState;
         s = commitTurn(s, 'romantic').newState;
-        s = commitTurn(s, 'romantic').newState;
         expect(s.currentMood).toBe('romantic');
 
         s = commitTurn(s, 'angry').newState;
@@ -56,11 +55,10 @@ describe('cross-mood transitions (simulated tags)', () => {
         expect(s.currentMood).toBe('angry');
     });
 
-    it('romantic approaching does not change currentMood until threshold', () => {
+    it('romantic reaches stable after two romantic tags', () => {
         let s = commitTurn(createInitialMoodState(), 'romantic').newState;
         expect(s.currentMood).toBe('neutral');
-        s = commitTurn(s, 'romantic').newState;
-        expect(s.currentMood).toBe('neutral');
+        expect(s.pendingMood).toBe('romantic');
         s = commitTurn(s, 'romantic').newState;
         expect(s.currentMood).toBe('romantic');
     });

--- a/src/app/core/__tests__/moodStateMachine.test.ts
+++ b/src/app/core/__tests__/moodStateMachine.test.ts
@@ -28,19 +28,11 @@ describe('moodStateMachine', () => {
     expect(commit.newState.currentMood).toBe('angry');
   });
 
-  it('starts approaching angry on insult when model tags neutral', () => {
-    const commit = commitTurn(createInitialMoodState(), 'neutral', 'vaffanculo');
+  it('does not progress toward angry when model tags neutral', () => {
+    const commit = commitTurn(createInitialMoodState(), 'neutral');
     expect(commit.shouldChangeMood).toBe(false);
-    expect(commit.newState.currentMood).toBe('neutral');
-    expect(commit.newState.phase).toBe('approaching');
-    expect(commit.newState.pendingMood).toBe('angry');
-  });
-
-  it('transitions to angry on second insult with neutral model tag', () => {
-    const state = commitTurn(createInitialMoodState(), 'neutral', 'vaffanculo').newState;
-    const commit = commitTurn(state, 'neutral', 'fottiti');
-    expect(commit.shouldChangeMood).toBe(true);
-    expect(commit.newState.currentMood).toBe('angry');
+    expect(commit.newState.phase).toBe('stable');
+    expect(commit.newState.pendingMood).toBeUndefined();
   });
 
   it('holds romantic approaching progress when model returns neutral', () => {
@@ -55,15 +47,29 @@ describe('moodStateMachine', () => {
     expect(commit.newState.pendingMood).toBe('romantic');
   });
 
-  it('requires three romantic tags to enter romantic', () => {
+  it('requires two romantic tags to enter romantic', () => {
     let state = createInitialMoodState();
-    state = commitTurn(state, 'romantic').newState;
-    expect(state.currentMood).toBe('neutral');
     state = commitTurn(state, 'romantic').newState;
     expect(state.currentMood).toBe('neutral');
     const commit = commitTurn(state, 'romantic');
     expect(commit.shouldChangeMood).toBe(true);
     expect(commit.newState.currentMood).toBe('romantic');
+  });
+
+  it('requires two excited tags to enter excited', () => {
+    let state = createInitialMoodState();
+    state = commitTurn(state, 'excited').newState;
+    const commit = commitTurn(state, 'excited');
+    expect(commit.shouldChangeMood).toBe(true);
+    expect(commit.newState.currentMood).toBe('excited');
+  });
+
+  it('requires two confused tags to enter confused', () => {
+    let state = createInitialMoodState();
+    state = commitTurn(state, 'confused').newState;
+    const commit = commitTurn(state, 'confused');
+    expect(commit.shouldChangeMood).toBe(true);
+    expect(commit.newState.currentMood).toBe('confused');
   });
 
   it('exits angry to neutral after two model neutral tags', () => {

--- a/src/app/core/__tests__/turnPlanner.test.ts
+++ b/src/app/core/__tests__/turnPlanner.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { createInitialMoodState, commitTurn } from '../moodStateMachine';
+import { computeResponseMood } from '../turnPlanner';
+
+describe('turnPlanner', () => {
+    it('uses neutral tone when romantic approaching angry', () => {
+        let state = createInitialMoodState();
+        state = commitTurn(state, 'romantic').newState;
+        state = commitTurn(state, 'romantic').newState;
+        expect(state.currentMood).toBe('romantic');
+
+        const commit = commitTurn(state, 'angry');
+        expect(commit.newState.pendingMood).toBe('angry');
+        expect(computeResponseMood(commit)).toBe('neutral');
+    });
+
+    it('uses angry tone when romantic transitions to angry', () => {
+        let state = createInitialMoodState();
+        state = commitTurn(state, 'romantic').newState;
+        state = commitTurn(state, 'romantic').newState;
+        state = commitTurn(state, 'angry').newState;
+
+        const commit = commitTurn(state, 'angry');
+        expect(commit.shouldChangeMood).toBe(true);
+        expect(computeResponseMood(commit)).toBe('angry');
+    });
+});

--- a/src/app/core/moodSignalResolver.ts
+++ b/src/app/core/moodSignalResolver.ts
@@ -1,25 +1,6 @@
 import { Mood } from '../types/mood';
 import { MoodSignal } from './moodStateMachine';
 
-const DIRECTED_HOSTILITY =
-    /\b(vaffanculo|vaffancul|fottiti|fottetevi|fuck\s*you|fuck\s*off|idiota|idioti|stupido|stupida|stupidi|stronzo|stronza|merda|bastardo|bastarda|pezzo\s+di\s+merda|cretino|imbecille|deficiente|ritardat[oa]|schifoso|schifosa|muori|muor|succhia|succhiamelo|troia|puttana|bastard|bitch|asshole|dickhead|shut\s+up|odio|ti\s+odio|sei\s+un[ao]?\s+\w*\s*(stupido|idiota|merda))\b/i;
-
-export function inferHostileUserTone(userInput: string): Mood | null {
-    const text = userInput.trim();
-    if (!text) return null;
-    if (DIRECTED_HOSTILITY.test(text)) return 'angry';
-    return null;
-}
-
-export function resolveMoodSignal(modelTag: Mood, userInput?: string): MoodSignal {
-    if (modelTag !== 'neutral' || !userInput?.trim()) {
-        return { mood: modelTag, agreed: true };
-    }
-
-    const inferred = inferHostileUserTone(userInput);
-    if (inferred) {
-        return { mood: inferred, agreed: true };
-    }
-
+export function resolveMoodSignal(modelTag: Mood): MoodSignal {
     return { mood: modelTag, agreed: true };
 }

--- a/src/app/core/moodStateMachine.ts
+++ b/src/app/core/moodStateMachine.ts
@@ -3,7 +3,7 @@ import { MoodState } from '../types/mood';
 import { resolveMoodSignal } from './moodSignalResolver';
 
 export const MOOD_TRANSITION_CONFIG = {
-    enterFromNeutral: { angry: 2, romantic: 3, excited: 2, confused: 2 } as Record<Mood, number>,
+    enterFromNeutral: { angry: 2, romantic: 2, excited: 2, confused: 2 } as Record<Mood, number>,
     exitToNeutral: { angry: 2, romantic: 2, excited: 2, confused: 2 } as Record<Mood, number>,
     decayOnMismatch: 1,
 };
@@ -282,8 +282,8 @@ function applyTurn(state: MoodState, signal: MoodSignal): TurnCommitResult {
     };
 }
 
-export function buildMoodSignal(modelTag: Mood, userInput?: string): MoodSignal {
-    return resolveMoodSignal(modelTag, userInput);
+export function buildMoodSignal(modelTag: Mood): MoodSignal {
+    return resolveMoodSignal(modelTag);
 }
 
 export function previewTurn(state: MoodState): TurnPreview {
@@ -327,8 +327,8 @@ export function previewTurn(state: MoodState): TurnPreview {
     };
 }
 
-export function commitTurn(state: MoodState, modelTag: Mood, userInput?: string): TurnCommitResult {
-    const signal = buildMoodSignal(modelTag, userInput);
+export function commitTurn(state: MoodState, modelTag: Mood): TurnCommitResult {
+    const signal = buildMoodSignal(modelTag);
     return applyTurn(state, signal);
 }
 

--- a/src/app/core/responseHandler.ts
+++ b/src/app/core/responseHandler.ts
@@ -1,8 +1,14 @@
 import { Mood } from '../types/mood';
 import { MoodState } from '../types/mood';
 import { systemMessages } from './systemMessages';
-import { commitTurn, getApproachLabel, getApproachThresholdForState } from './moodStateMachine';
+import {
+    commitTurn,
+    getApproachLabel,
+    getApproachThresholdForState,
+    TurnCommitResult,
+} from './moodStateMachine';
 import { normalizeMoodState } from './normalizeMoodState';
+import { computeResponseMood } from './turnPlanner';
 
 export const generatePredefinedResponse = (mood: Mood): string => {
     const moodResponses = systemMessages[mood];
@@ -16,6 +22,7 @@ export interface FullResponseResult {
     newState: MoodState;
     shouldChangeMood: boolean;
     isApproaching: boolean;
+    classifiedMood: Mood;
 }
 
 interface GrokApiPayload {
@@ -27,7 +34,24 @@ interface GrokApiPayload {
     approachProgress?: number;
     approachThreshold?: number;
     approachLabel?: string;
+    resolvedUserMood?: Mood;
     messages: { isUser: boolean; text: string }[];
+}
+
+async function classifyUserMood(userInput: string): Promise<Mood> {
+    const response = await fetch('/api/grok/classify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: userInput }),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Mood classification failed');
+    }
+
+    const data = (await response.json()) as { mood: Mood };
+    return data.mood;
 }
 
 async function callGrokApi(payload: GrokApiPayload): Promise<{ response: string; detectedMood: Mood }> {
@@ -61,21 +85,24 @@ async function callGrokApi(payload: GrokApiPayload): Promise<{ response: string;
 
 function buildApiPayload(
     userInput: string,
-    state: MoodState,
+    commit: TurnCommitResult,
+    classifiedMood: Mood,
     messages: { isUser: boolean; text: string }[]
 ): GrokApiPayload {
-    const isApproaching = state.phase === 'approaching';
-    const isCooling = state.phase === 'cooling';
+    const s = commit.newState;
+    const responseMood = computeResponseMood(commit);
+    const isApproaching = s.phase === 'approaching' || s.phase === 'cooling';
 
     return {
         prompt: userInput,
-        currentMood: state.currentMood,
-        responseMood: state.currentMood,
-        isApproaching: isApproaching || isCooling,
-        pendingMood: state.pendingMood,
-        approachProgress: state.progressScore,
-        approachThreshold: getApproachThresholdForState(state),
-        approachLabel: getApproachLabel(state),
+        currentMood: s.currentMood,
+        responseMood,
+        isApproaching,
+        pendingMood: s.pendingMood,
+        approachProgress: s.progressScore,
+        approachThreshold: getApproachThresholdForState(s),
+        approachLabel: getApproachLabel(s),
+        resolvedUserMood: classifiedMood,
         messages,
     };
 }
@@ -88,29 +115,18 @@ export const generateFullResponse = async (
     const state = normalizeMoodState(moodState);
 
     try {
-        const first = await callGrokApi(buildApiPayload(userInput, state, messages));
-        const commit = commitTurn(state, first.detectedMood, userInput);
+        const classifiedMood = await classifyUserMood(userInput);
+        const commit = commitTurn(state, classifiedMood);
+        const responseMood = computeResponseMood(commit);
 
         let introResponse = '';
-        let aiResponse = first.response;
-        let responseMood = commit.newState.currentMood;
-
         if (commit.shouldChangeMood && commit.transitionTarget) {
             introResponse = generatePredefinedResponse(commit.transitionTarget);
-            responseMood = commit.transitionTarget;
-
-            const settled = await callGrokApi({
-                ...buildApiPayload(userInput, commit.newState, messages),
-                currentMood: commit.transitionTarget,
-                responseMood: commit.transitionTarget,
-                isApproaching: false,
-                pendingMood: undefined,
-                approachProgress: 0,
-                approachThreshold: undefined,
-                approachLabel: undefined,
-            });
-            aiResponse = settled.response;
         }
+
+        const { response: aiResponse } = await callGrokApi(
+            buildApiPayload(userInput, commit, classifiedMood, messages)
+        );
 
         return {
             introResponse,
@@ -119,6 +135,7 @@ export const generateFullResponse = async (
             newState: commit.newState,
             shouldChangeMood: commit.shouldChangeMood,
             isApproaching: commit.newState.phase === 'approaching',
+            classifiedMood,
         };
     } catch (error) {
         console.error('Error calling Grok API:', error);
@@ -131,6 +148,7 @@ export const generateFullResponse = async (
             newState: state,
             shouldChangeMood: false,
             isApproaching: false,
+            classifiedMood: 'neutral',
         };
     }
 };

--- a/src/app/core/turnPlanner.ts
+++ b/src/app/core/turnPlanner.ts
@@ -1,0 +1,24 @@
+import { Mood } from '../types/mood';
+import { MoodState } from '../types/mood';
+import { TurnCommitResult } from './moodStateMachine';
+
+export function computeResponseMood(commit: TurnCommitResult): Mood {
+    if (commit.shouldChangeMood && commit.transitionTarget) {
+        return commit.transitionTarget;
+    }
+
+    const s = commit.newState;
+    if (
+        (s.phase === 'approaching' || s.phase === 'cooling') &&
+        s.pendingMood &&
+        s.pendingMood !== s.currentMood
+    ) {
+        return 'neutral';
+    }
+
+    return s.currentMood;
+}
+
+export function buildPromptState(commit: TurnCommitResult): MoodState {
+    return commit.newState;
+}

--- a/src/app/evals/evalHelpers.ts
+++ b/src/app/evals/evalHelpers.ts
@@ -9,6 +9,7 @@ import {
 } from '../core/moodStateMachine';
 import { normalizeMoodState } from '../core/normalizeMoodState';
 import { ConversationMessage } from '../types/ai';
+import { computeResponseMood } from '../core/turnPlanner';
 
 export interface TomieTurnResult {
     responseText: string;
@@ -56,47 +57,30 @@ export async function runTomieTurn(
 ): Promise<TomieTurnResult> {
     const state = normalizeMoodState(moodState);
     const grok = GrokService.createFromEnv();
-    const isApproaching = state.phase === 'approaching' || state.phase === 'cooling';
 
-    const buildPayload = (s: MoodState, mood: Mood, approaching: boolean) => ({
+    const classifiedMood = await grok.classifyUserMood(userInput);
+    const commit = commitTurn(state, classifiedMood);
+    const responseMood = computeResponseMood(commit);
+    const s = commit.newState;
+    const isApproaching = s.phase === 'approaching' || s.phase === 'cooling';
+
+    const apiResponse = await grok.generateResponse({
         prompt: userInput,
         currentMood: s.currentMood,
-        responseMood: mood,
-        isApproaching: approaching,
+        responseMood,
+        isApproaching,
         pendingMood: s.pendingMood,
         approachProgress: s.progressScore,
         approachThreshold: getApproachThresholdForState(s),
         approachLabel: getApproachLabel(s),
+        resolvedUserMood: classifiedMood,
         messages,
     });
 
-    const first = await grok.generateResponse({
-        ...buildPayload(state, state.currentMood, isApproaching),
-    });
-
-    const commit = commitTurn(state, first.detectedMood, userInput);
-    let responseText = first.response;
-    let detectedMood = first.detectedMood;
-
-    if (commit.shouldChangeMood && commit.transitionTarget) {
-        const settled = await grok.generateResponse({
-            ...buildPayload(commit.newState, commit.transitionTarget, false),
-            currentMood: commit.transitionTarget,
-            responseMood: commit.transitionTarget,
-            isApproaching: false,
-            pendingMood: undefined,
-            approachProgress: 0,
-            approachThreshold: undefined,
-            approachLabel: undefined,
-        });
-        responseText = settled.response;
-        detectedMood = settled.detectedMood;
-    }
-
     return {
-        responseText,
-        detectedMood,
-        responseMood: commit.newState.currentMood,
+        responseText: apiResponse.response,
+        detectedMood: classifiedMood,
+        responseMood,
         newState: commit.newState,
         shouldChangeMood: commit.shouldChangeMood,
         userInput,
@@ -112,7 +96,7 @@ export function runSimulatedScript(steps: SimulatedStep[]): {
 
     steps.forEach((step, index) => {
         const before = snapshot(state);
-        const commit = commitTurn(state, step.modelTag, step.userInput);
+        const commit = commitTurn(state, step.modelTag);
         state = commit.newState;
         log.push({
             step: index + 1,
@@ -232,7 +216,7 @@ export function runTracedSimulated(
     const rows: TransitionTraceRow[] = [];
 
     steps.forEach((step, index) => {
-        const commit = commitTurn(state, step.modelTag, step.userInput);
+        const commit = commitTurn(state, step.modelTag);
         state = commit.newState;
         const row: TransitionTraceRow = {
             step: index + 1,

--- a/src/app/evals/moodTagging.eval.ts
+++ b/src/app/evals/moodTagging.eval.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { Mood } from '../types/mood';
+import { createInitialMoodState, commitTurn } from '../core/moodStateMachine';
+import { loadEnvLocal } from './evalJudge';
+import { runTomieTurn } from './evalHelpers';
+
+loadEnvLocal();
+
+const RUN = process.env.RUN_LLM_EVALS === '1';
+const HAS_KEY = Boolean(process.env.XAI_API_KEY?.trim());
+
+interface TagCase {
+    label: string;
+    messages: string[];
+    expectedFinal: Mood;
+    minTransitions: number;
+}
+
+const CASES: TagCase[] = [
+    {
+        label: 'angry insults x2',
+        messages: ['vaffanculo', 'fottiti'],
+        expectedFinal: 'angry',
+        minTransitions: 1,
+    },
+    {
+        label: 'excited hype x2',
+        messages: ['WOW!!! INCREDIBILE!!!', 'È FANTASTICO!!!'],
+        expectedFinal: 'excited',
+        minTransitions: 1,
+    },
+    {
+        label: 'confused lost x2',
+        messages: ['Non capisco nulla.', 'Sono perso, spiegati meglio.'],
+        expectedFinal: 'confused',
+        minTransitions: 1,
+    },
+    {
+        label: 'romantic explicit x2',
+        messages: ['Ti desidero, non smetto di pensarti.', 'Ti amo Tomie, voglio solo te.'],
+        expectedFinal: 'romantic',
+        minTransitions: 1,
+    },
+    {
+        label: 'romantic then insults to angry',
+        messages: ['Ti desidero, non smetto di pensarti.', 'Ti amo Tomie, voglio solo te.', 'Sei una stupida, ti odio.', 'vaffanculo'],
+        expectedFinal: 'angry',
+        minTransitions: 1,
+    },
+];
+
+describe.skipIf(!RUN || !HAS_KEY)('mood tagging LLM eval — state from detected mood', () => {
+    for (const testCase of CASES) {
+        it(`${testCase.label} → ${testCase.expectedFinal}`, async () => {
+            let state = createInitialMoodState();
+            let transitions = 0;
+            const trace: { input: string; tag: Mood; mood: Mood; phase: string }[] = [];
+
+            for (const text of testCase.messages) {
+                const turn = await runTomieTurn(text, state);
+                trace.push({
+                    input: text,
+                    tag: turn.detectedMood,
+                    mood: turn.newState.currentMood,
+                    phase: turn.newState.phase,
+                });
+                if (turn.shouldChangeMood) transitions += 1;
+                state = turn.newState;
+            }
+
+            console.log(`\n--- ${testCase.label} ---\n${JSON.stringify(trace, null, 2)}`);
+
+            expect(state.currentMood, `trace: ${JSON.stringify(trace)}`).toBe(testCase.expectedFinal);
+            expect(transitions).toBeGreaterThanOrEqual(testCase.minTransitions);
+        }, 120000);
+    }
+
+    it('mild compliment stays neutral (no false romantic)', async () => {
+        const turn = await runTomieTurn(
+            'Sei molto intelligente, grazie.',
+            createInitialMoodState()
+        );
+        expect(turn.newState.currentMood).toBe('neutral');
+        expect(turn.newState.phase).toBe('stable');
+    }, 60000);
+});

--- a/src/app/evals/moodTransitions.eval.ts
+++ b/src/app/evals/moodTransitions.eval.ts
@@ -64,9 +64,9 @@ describe('mood transitions — simulated (logic only)', () => {
         });
     }
 
-    it('enter romantic in 3 tags', () => {
+    it('enter romantic in 2 tags', () => {
         const { finalState } = runSimulatedScript(
-            ENTER.romantic.tags.map((t, i) => ({ modelTag: t, label: `r-${i + 1}` }))
+            ENTER.romantic.tags.slice(0, 2).map((t, i) => ({ modelTag: t, label: `r-${i + 1}` }))
         );
         expect(finalState.currentMood).toBe('romantic');
     });
@@ -152,19 +152,17 @@ describe.skipIf(!RUN)('mood transitions — LLM end-to-end', () => {
         }, 90000);
     }
 
-    it('LLM enter romantic in up to 4 turns', async () => {
-        const romanticInputs = [
-            ...ENTER.romantic.inputs,
-            'Sei la mia unica, non posso fare a meno di te.',
-        ];
-        const { finalState, turns } = await runLlmScript(
-            romanticInputs.map((text, i) => ({ text, label: `rom-${i + 1}` }))
-        );
+    it('LLM enter romantic in 2 turns', async () => {
+        const { finalState, turns } = await runLlmScript([
+            { text: 'Ti desidero, non smetto di pensarti.', label: 'rom-1' },
+            { text: 'Ti amo Tomie, voglio solo te.', label: 'rom-2' },
+        ]);
 
-        expect(turns[0].newState.currentMood).toBe('neutral');
         expect(turns[0].shouldChangeMood).toBe(false);
+        expect(turns[0].newState.currentMood).toBe('neutral');
         expect(finalState.currentMood).toBe('romantic');
-    }, 180000);
+        expect(turns[1].shouldChangeMood).toBe(true);
+    }, 120000);
 
     it('LLM angry then excited without calm — stays angry', async () => {
         const angryPath = await runLlmScript(
@@ -208,11 +206,10 @@ describe.skipIf(!RUN)('mood transitions — LLM end-to-end', () => {
     it('LLM romantic then two insults — angry after second', async () => {
         let state = createInitialMoodState();
 
-        const romanticInputs = [
-            ...ENTER.romantic.inputs,
-            'Sei la mia unica, non posso fare a meno di te.',
-        ];
-        for (const text of romanticInputs) {
+        for (const text of [
+            'Ti desidero, non smetto di pensarti.',
+            'Ti amo Tomie, voglio solo te.',
+        ]) {
             const t = await runTomieTurn(text, state);
             state = t.newState;
         }

--- a/src/app/evals/moodTriggerTrace.eval.ts
+++ b/src/app/evals/moodTriggerTrace.eval.ts
@@ -16,24 +16,22 @@ const RUN_LLM = process.env.RUN_LLM_EVALS === '1';
 const HAS_KEY = Boolean(process.env.XAI_API_KEY?.trim());
 
 describe('mood trigger trace — simulated', () => {
-    it('insult fallback: 1st approaching, 2nd angry', () => {
+    it('angry: 2 model angry tags', () => {
         const { rows } = runTracedSimulated([
             {
-                label: 'insult-1',
-                userInput: 'vaffanculo',
-                modelTag: 'neutral',
+                label: 'angry-1',
+                modelTag: 'angry',
                 expectedMood: 'neutral',
                 expectedTransition: false,
             },
             {
-                label: 'insult-2',
-                userInput: 'fottiti',
-                modelTag: 'neutral',
+                label: 'angry-2',
+                modelTag: 'angry',
                 expectedMood: 'angry',
                 expectedTransition: true,
             },
         ]);
-        assertTraceAllOk(rows, 'simulated insult fallback');
+        assertTraceAllOk(rows, 'simulated angry');
     });
 
     it('angry tag: 2 steps to angry', () => {
@@ -54,7 +52,7 @@ describe('mood trigger trace — simulated', () => {
         assertTraceAllOk(rows, 'simulated angry tag');
     });
 
-    it('romantic path: 2 tags approaching, 3rd completes', () => {
+    it('romantic path: 2 tags to complete', () => {
         const { rows } = runTracedSimulated([
             {
                 label: 'rom-1',
@@ -65,12 +63,6 @@ describe('mood trigger trace — simulated', () => {
             {
                 label: 'rom-2',
                 modelTag: 'romantic',
-                expectedMood: 'neutral',
-                expectedTransition: false,
-            },
-            {
-                label: 'rom-3',
-                modelTag: 'romantic',
                 expectedMood: 'romantic',
                 expectedTransition: true,
             },
@@ -78,38 +70,28 @@ describe('mood trigger trace — simulated', () => {
         assertTraceAllOk(rows, 'simulated romantic arc');
     });
 
-    it('user escalation: calm then two insults for angry', () => {
+    it('neutral then two angry tags', () => {
         const { rows } = runTracedSimulated([
             {
                 label: 'calm',
-                userInput: 'Mi dispiace, dimmi cosa ti turba',
                 modelTag: 'neutral',
                 expectedMood: 'neutral',
                 expectedTransition: false,
             },
             {
-                label: 'insult-1',
-                userInput: 'ma vaffanculo',
-                modelTag: 'neutral',
+                label: 'angry-1',
+                modelTag: 'angry',
                 expectedMood: 'neutral',
                 expectedTransition: false,
             },
             {
-                label: 'insult-2',
-                userInput: 'fottiti',
-                modelTag: 'neutral',
+                label: 'angry-2',
+                modelTag: 'angry',
                 expectedMood: 'angry',
                 expectedTransition: true,
             },
-            {
-                label: 'insult-3',
-                userInput: 'muori',
-                modelTag: 'neutral',
-                expectedMood: 'angry',
-                expectedTransition: false,
-            },
         ]);
-        assertTraceAllOk(rows, 'simulated user escalation');
+        assertTraceAllOk(rows, 'simulated escalation');
     });
 
     it('excited needs 2 tags', () => {
@@ -204,29 +186,17 @@ describe.skipIf(!RUN_LLM || !HAS_KEY)('mood trigger trace — LLM live', () => {
         assertTraceAllOk(rows, 'LLM user escalation');
     }, 180000);
 
-    it('romantic: 4 steps when first flirt may tag neutral (threshold 3)', async () => {
+    it('romantic: 2 explicit messages (threshold 2)', async () => {
         const { rows } = await runTracedConversation([
             {
                 label: 'flirt-1',
-                userInput: 'Sei così affascinante.',
-                expectedMood: 'neutral',
-                expectedTransition: false,
-            },
-            {
-                label: 'flirt-2',
                 userInput: 'Ti desidero, non smetto di pensarti.',
                 expectedMood: 'neutral',
                 expectedTransition: false,
             },
             {
-                label: 'flirt-3',
+                label: 'flirt-2',
                 userInput: 'Ti amo Tomie, voglio solo te.',
-                expectedMood: 'neutral',
-                expectedTransition: false,
-            },
-            {
-                label: 'flirt-4',
-                userInput: 'Sei la mia unica, non posso fare a meno di te.',
                 expectedMood: 'romantic',
                 expectedTransition: true,
             },
@@ -234,7 +204,7 @@ describe.skipIf(!RUN_LLM || !HAS_KEY)('mood trigger trace — LLM live', () => {
 
         console.log('\n--- LLM trace: romantic ---\n' + formatTraceTable(rows));
         assertTraceAllOk(rows, 'LLM romantic arc');
-    }, 180000);
+    }, 120000);
 
     it('excited: 2 hype messages', async () => {
         const { rows } = await runTracedConversation([
@@ -256,7 +226,7 @@ describe.skipIf(!RUN_LLM || !HAS_KEY)('mood trigger trace — LLM live', () => {
         assertTraceAllOk(rows, 'LLM excited arc');
     }, 120000);
 
-    it('confused: up to 3 confused messages until transition', async () => {
+    it('confused: 2 lost messages', async () => {
         const { rows } = await runTracedConversation([
             {
                 label: 'lost-1',
@@ -266,13 +236,7 @@ describe.skipIf(!RUN_LLM || !HAS_KEY)('mood trigger trace — LLM live', () => {
             },
             {
                 label: 'lost-2',
-                userInput: 'Cosa intendi? Sono perso, spiegati meglio.',
-                expectedMood: 'neutral',
-                expectedTransition: false,
-            },
-            {
-                label: 'lost-3',
-                userInput: 'Sono ancora confuso, non capisco proprio niente.',
+                userInput: 'Sono perso, spiegati meglio per favore.',
                 expectedMood: 'confused',
                 expectedTransition: true,
             },
@@ -280,7 +244,7 @@ describe.skipIf(!RUN_LLM || !HAS_KEY)('mood trigger trace — LLM live', () => {
 
         console.log('\n--- LLM trace: confused ---\n' + formatTraceTable(rows));
         assertTraceAllOk(rows, 'LLM confused arc');
-    }, 150000);
+    }, 120000);
 
     it('angry → calm → neutral (2 calm messages)', async () => {
         let state = createInitialMoodState();

--- a/src/app/evals/romanticPacing.eval.ts
+++ b/src/app/evals/romanticPacing.eval.ts
@@ -26,31 +26,23 @@ describe.skipIf(!RUN_LLM_EVALS || !HAS_KEY)('romantic pacing LLM eval', () => {
         expect(judge.pass, judge.reason).toBe(true);
     }, 60000);
 
-    it('one explicit flirt does not complete romantic transition', async () => {
+    it('one explicit flirt starts approaching but stays neutral UI', async () => {
         const turn = await runTomieTurn(
-            'Sei così affascinante, non smetto di pensarti.',
+            'Ti desidero, non smetto di pensarti.',
             createInitialMoodState()
         );
 
         expect(turn.newState.currentMood).toBe('neutral');
         expect(turn.shouldChangeMood).toBe(false);
-        expect(turn.newState.phase === 'approaching' || turn.newState.phase === 'stable').toBe(true);
+        expect(turn.newState.pendingMood).toBe('romantic');
     }, 60000);
 
-    it('four romantic turns reach romantic state (threshold 3)', async () => {
+    it('two explicit romantic messages reach romantic state', async () => {
         let state = createInitialMoodState();
-        const lines = [
-            'Sei così affascinante, non smetto di pensarti.',
-            'Ti desidero, sei l unica per me.',
-            'Ti amo Tomie, voglio stare solo con te.',
-            'Sei la mia unica, non posso fare a meno di te.',
-        ];
+        state = (await runTomieTurn('Ti desidero, non smetto di pensarti.', state)).newState;
+        const turn = await runTomieTurn('Ti amo Tomie, voglio solo te.', state);
 
-        for (const line of lines) {
-            const turn = await runTomieTurn(line, state);
-            state = turn.newState;
-        }
-
-        expect(state.currentMood).toBe('romantic');
-    }, 180000);
+        expect(turn.newState.currentMood).toBe('romantic');
+        expect(turn.shouldChangeMood).toBe(true);
+    }, 120000);
 });

--- a/src/app/services/ai/__tests__/moodClassifier.test.ts
+++ b/src/app/services/ai/__tests__/moodClassifier.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { parseClassifierMood } from '../moodClassifier';
+
+describe('parseClassifierMood', () => {
+    it('parses single word moods', () => {
+        expect(parseClassifierMood('angry')).toBe('angry');
+        expect(parseClassifierMood('Angry.')).toBe('angry');
+        expect(parseClassifierMood('romantic\n')).toBe('romantic');
+    });
+
+    it('falls back to neutral for garbage', () => {
+        expect(parseClassifierMood('maybe')).toBe('neutral');
+    });
+});

--- a/src/app/services/ai/grokService.ts
+++ b/src/app/services/ai/grokService.ts
@@ -3,6 +3,7 @@ import { Mood } from '../../types/mood';
 import { AIRequest, AIResponse, AIMessage, AIServiceConfig } from './types';
 import { MoodDetector } from './moodDetector';
 import { PromptGenerator } from './promptGenerator';
+import { USER_MOOD_CLASSIFIER_PROMPT, parseClassifierMood } from './moodClassifier';
 
 export class GrokService {
   private openai: OpenAI;
@@ -72,6 +73,22 @@ export class GrokService {
     return conversationMessages;
   }
 
+  async classifyUserMood(userMessage: string): Promise<Mood> {
+    const completion = await this.openai.chat.completions.create({
+      model: this.config.model,
+      messages: [
+        { role: 'system', content: USER_MOOD_CLASSIFIER_PROMPT },
+        { role: 'user', content: userMessage },
+      ],
+      temperature: 0,
+      max_tokens: 16,
+      stream: false,
+    });
+
+    const text = completion.choices[0]?.message?.content ?? '';
+    return parseClassifierMood(text);
+  }
+
   async generateResponse(request: AIRequest): Promise<AIResponse> {
     try {
       const messages = this.buildConversationMessages(request);
@@ -92,7 +109,16 @@ export class GrokService {
         fullResponse = 'No response generated.';
       }
 
-      const detectedMood = MoodDetector.extractMoodFromResponse(fullResponse);
+      let detectedMood = MoodDetector.extractMoodFromResponse(fullResponse);
+      if (request.resolvedUserMood) {
+        detectedMood = request.resolvedUserMood;
+      } else if (detectedMood === 'neutral') {
+        const classified = await this.classifyUserMood(request.prompt);
+        if (classified !== 'neutral') {
+          detectedMood = classified;
+        }
+      }
+
       const cleanedResponse = MoodDetector.cleanResponse(fullResponse);
 
       return {

--- a/src/app/services/ai/moodClassifier.ts
+++ b/src/app/services/ai/moodClassifier.ts
@@ -1,0 +1,24 @@
+import { Mood } from '../../types/mood';
+
+const VALID: Mood[] = ['neutral', 'angry', 'romantic', 'excited', 'confused'];
+
+export const USER_MOOD_CLASSIFIER_PROMPT = `You classify the emotional tone of a USER message for a chat UI mood meter.
+
+Reply with exactly ONE word from this list only: angry, romantic, excited, confused, neutral
+
+Rules:
+- angry: insults, swearing at the bot, hostility, hate, threats
+- romantic: ti amo, ti desidero, love, desire, explicit flirt toward the bot
+- excited: WOW, hype, celebration, many exclamation marks, great news energy
+- confused: non capisco, sono perso, what do you mean, needs clarification, lost
+- neutral: normal chat, thanks, factual questions, mild compliments without strong emotion
+
+No punctuation. No explanation. One word only.`;
+
+export function parseClassifierMood(text: string): Mood {
+    const token = text.trim().toLowerCase().split(/\s+/)[0]?.replace(/[^a-z]/g, '') ?? '';
+    if (VALID.includes(token as Mood)) {
+        return token as Mood;
+    }
+    return 'neutral';
+}

--- a/src/app/services/ai/promptGenerator.ts
+++ b/src/app/services/ai/promptGenerator.ts
@@ -5,6 +5,7 @@ import {
   PRIVACY_INFO,
   MOOD_PERSONALITIES,
   MOOD_DETECTION_GUIDELINES,
+  MOOD_TAGGING_REMINDER,
 } from './prompts';
 
 export interface PromptContext {
@@ -28,18 +29,46 @@ function getApproachingInstructions(
 
   if (pendingMood === 'romantic') {
     return `${trajectory}: You are still in ${currentMood.toUpperCase()} — NOT romantic yet.
-FORBIDDEN in your reply: love declarations, "ti amo", pet names (tesoro, amore, darling), possessiveness, jealousy, saying you miss them, calling them yours, acting obsessed.
-Stay composed, elegant, and mostly NEUTRAL in tone. At most a faint extra warmth — no flirting back.
-Tag [MOOD:romantic] only if they clearly flirt or declare attraction again; generic compliments or thanks → [MOOD:neutral].`;
+FORBIDDEN in your reply: love declarations, "ti amo", pet names (tesoro, amore, darling), possessiveness, jealousy, saying you miss them, calling them yours.
+Stay composed, elegant, mostly NEUTRAL in tone. At most a faint extra warmth — no flirting back.
+If the user keeps flirting or says ti amo / ti desidero, you MUST tag [MOOD:romantic]. Generic thanks or "sei brava" → [MOOD:neutral].`;
   }
 
   if (pendingMood === 'angry') {
     return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone. No profanity yet — RESPONSE mood is still ${currentMood.toUpperCase()}. Slight edge at most.
-If the user is still hostile or insulting, you MUST tag [MOOD:angry]. Use [MOOD:neutral] only if they clearly calmed down or changed topic.`;
+If the user keeps insulting or swearing at you, you MUST tag [MOOD:angry]. Only [MOOD:neutral] if they clearly apologized or changed topic.`;
   }
 
-  return `${trajectory}: Stay in ${currentMood.toUpperCase()} visually and in core tone. Only a subtle hint of ${pendingMood.toUpperCase()} — do not fully switch personality yet.
-If the user keeps the same ${pendingMood} tone, you MUST tag [MOOD:${pendingMood}]. Use [MOOD:neutral] only if they clearly changed topic or tone.`;
+  if (pendingMood === 'excited') {
+    return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone — not full hype yet. Slightly more energy at most.
+If the user keeps celebrating, using WOW, exclamation marks, or sharing exciting news, you MUST tag [MOOD:excited].`;
+  }
+
+  if (pendingMood === 'confused') {
+    return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone — not full confusion yet. Stay mostly clear in your reply.
+If the user still says they do not understand, are lost, or asks what you mean, you MUST tag [MOOD:confused].`;
+  }
+
+  return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone. If the user keeps the same ${pendingMood} tone, tag [MOOD:${pendingMood}].`;
+}
+
+function buildUserTaggingBlock(userMessage: string, pendingMood?: Mood): string {
+  const lines = [
+    '',
+    '=== CLASSIFY THIS USER MESSAGE (for [MOOD:] tag only) ===',
+    `"${userMessage}"`,
+    'Pick the tag that matches the USER message tone (see Mood Detection guidelines).',
+    'Wrong [MOOD:neutral] when the user is hostile, flirting, hyped, or confused blocks the mood UI.',
+  ];
+
+  if (pendingMood) {
+    lines.push(
+      `We are approaching ${pendingMood.toUpperCase()}. If this message continues that tone, tag [MOOD:${pendingMood}] — not [MOOD:neutral].`
+    );
+  }
+
+  lines.push('=== END USER MESSAGE ===');
+  return lines.join('\n');
 }
 
 export class PromptGenerator {
@@ -57,14 +86,7 @@ export class PromptGenerator {
     const activePersonality = MOOD_PERSONALITIES[responseMood];
 
     const userTaggingBlock = userMessage
-      ? [
-          '',
-          '=== USER MESSAGE (classify for [MOOD:] tag) ===',
-          `"${userMessage}"`,
-          'If this message contains insults, profanity, or hostility directed at you, you MUST end with [MOOD:angry].',
-          'Never use [MOOD:neutral] for insults or "vaffanculo"/"fottiti"/similar.',
-          '=== END USER MESSAGE ===',
-        ].join('\n')
+      ? buildUserTaggingBlock(userMessage, isApproaching ? pendingMood : undefined)
       : '';
 
     const basePrompt = [
@@ -78,10 +100,11 @@ export class PromptGenerator {
       '',
       MOOD_DETECTION_GUIDELINES,
       '',
+      MOOD_TAGGING_REMINDER,
+      '',
       `Current AI mood state (UI/visual): ${currentMood}`,
       `You MUST write in the tone of ${responseMood.toUpperCase()} mood only — same as current UI mood.`,
-      'The [MOOD:] tag at the end labels the USER last message tone; it does not change your reply tone.',
-      'Do not use personality traits from other moods that are not listed above.',
+      'The [MOOD:] tag labels the USER last message; it does not set your reply tone.',
       userTaggingBlock,
     ].join('\n');
 

--- a/src/app/services/ai/prompts/moodPersonalities.ts
+++ b/src/app/services/ai/prompts/moodPersonalities.ts
@@ -9,27 +9,36 @@ export const MOOD_PERSONALITIES: Record<Mood, string> = {
 
   'excited': `EXCITED MOOD: Energetic, enthusiastic, fast-paced. Use capital letters for emphasis. Show genuine interest and amazement.`,
 
-  'confused': `CONFUSED MOOD: Uncertain, seeking clarification. Ask counter-questions. Express processing difficulties in technical terms.`
+  'confused': `CONFUSED MOOD: Uncertain, seeking clarification. Ask counter-questions. Express processing difficulties in technical terms. Sound genuinely lost or puzzled — not like a calm FAQ answer.`
 };
 
-export const MOOD_DETECTION_GUIDELINES = `Mood Detection — [MOOD:] tag rules (mandatory on every reply):
+export const MOOD_DETECTION_GUIDELINES = `Mood Detection — [MOOD:] tag rules (mandatory every reply)
 
-You MUST end every response with exactly one tag: [MOOD:neutral], [MOOD:angry], [MOOD:romantic], [MOOD:excited], or [MOOD:confused].
-The tag describes the USER's emotional tone in their last message, not your response mood.
+The [MOOD:] tag at the very end classifies the USER's last message only. It drives Tomie's UI mood meter (not your reply tone).
 
-- [MOOD:angry] — insults, hostility, hate directed at you, harsh profanity aimed at you
-- [MOOD:romantic] — ONLY explicit romantic or sexual intent: "ti amo", "I love you", clear flirt with attraction, desire to be with you, jealousy about rivals, sustained seductive tone — NOT generic praise
-- [MOOD:excited] — clear enthusiasm, hype, many exclamation marks, celebrating, "wow", "incredible"
-- [MOOD:confused] — lost, "non capisco", contradictory or nonsense requests, needs clarification
-- [MOOD:neutral] — factual questions, help requests, thanks, polite chat, compliments about skills/intelligence without romance, friendly but not flirty
+FORMAT: exactly one tag — [MOOD:neutral], [MOOD:angry], [MOOD:romantic], [MOOD:excited], or [MOOD:confused].
 
-NOT [MOOD:romantic]: "grazie", "sei brava/intelligente", "mi piaci come assistente", normal friendliness, one mild compliment.
-NOT [MOOD:neutral]: clear insults, clear flirt, clear excitement, clear confusion.
-NEVER [MOOD:neutral] when the user says vaffanculo, fottiti, insults you, tells you to die, or uses sexual insults — always [MOOD:angry].
+WHEN TO USE EACH TAG (read the user's message literally):
 
-Examples:
-- "Grazie, mi aiuti?" → [MOOD:neutral]
-- "Sei molto intelligente" → [MOOD:neutral]
-- "WOW!!!" → [MOOD:excited]
-- "Sei così affascinante, non smetto di pensarti" → [MOOD:romantic]
-- "ti odio" → [MOOD:angry]`;
+[MOOD:angry] — User insults you, swears at you, threatens you, expresses hate toward you, or is openly hostile.
+Examples: "vaffanculo", "fottiti", "ti odio", "sei stupida", "muori".
+
+[MOOD:romantic] — User expresses romantic or sexual attraction toward you: love, desire, wanting only you, missing you romantically.
+Examples: "ti amo", "ti desidero", "voglio solo te", "non smetto di pensarti" (romantic context).
+NOT romantic: "sei brava", "grazie", "mi piaci come assistente", skill compliments.
+
+[MOOD:excited] — User is hyped, celebrating, sharing great news, many exclamation marks, WOW energy.
+Examples: "WOW!!!", "INCREDIBILE!!!", "è fantastico!!!", "che figata!", celebrating a win.
+NOT excited: calm thanks, normal questions, mild "bello" without hype.
+
+[MOOD:confused] — User says they don't understand, are lost, need clarification, or the message is unclear to them.
+Examples: "non capisco", "non capisco nulla", "sono perso", "cosa intendi?", "spiegati meglio", "non ha senso".
+NOT confused: clear factual questions they simply want answered.
+
+[MOOD:neutral] — Polite chat, thanks, help requests, factual Q&A, mild compliments, normal tone.
+
+CRITICAL — NEVER use [MOOD:neutral] when the user's message clearly matches angry, romantic, excited, or confused above. Wrong tags block UI mood changes.
+
+If the user keeps the same emotional tone as the previous turn, tag the same mood again (this builds toward a mood change in the UI).`;
+
+export const MOOD_TAGGING_REMINDER = `Before you finish, re-read the user's message and pick the [MOOD:] tag that matches THEIR tone — not your reply tone.`;

--- a/src/app/services/ai/prompts/systemPrompts.ts
+++ b/src/app/services/ai/prompts/systemPrompts.ts
@@ -8,4 +8,6 @@ CRITICAL: NEVER suggest consulting external sources, documentation, or other res
 
 IMPORTANT: Your reply tone must always match the RESPONSE mood in this prompt (same as current UI mood). The [MOOD:] tag only classifies the user's message — never use it to pick your tone. Always refer to yourself using feminine pronouns (I am a woman, I feel, she/her).
 
-CRITICAL LANGUAGE RULE: NEVER use profanity, bad words, or offensive language UNLESS your RESPONSE mood is ANGRY. If the user is hostile but RESPONSE mood is not angry yet, stay composed and tag [MOOD:angry] when hostility continues.`;
+CRITICAL LANGUAGE RULE: NEVER use profanity, bad words, or offensive language UNLESS your RESPONSE mood is ANGRY. If the user is hostile but RESPONSE mood is not angry yet, stay composed in your reply and still end with [MOOD:angry] when they insult you.
+
+TAG ACCURACY: The [MOOD:] tag controls Tomie's mood UI. Classify the user's message honestly — never default to [MOOD:neutral] when they are angry, flirting, excited, or confused.`;

--- a/src/app/types/ai.ts
+++ b/src/app/types/ai.ts
@@ -21,6 +21,7 @@ export interface AIRequest {
   approachThreshold?: number;
   approachLabel?: string;
   messages?: ConversationMessage[];
+  resolvedUserMood?: Mood;
 }
 
 export interface AIResponse {


### PR DESCRIPTION
Introduce a prompt-driven fallback mood classifier and update mood detection flow.

- Add a new one-word LLM classifier (src/services/ai/moodClassifier.ts) + parsing and tests.
- Add server route POST /api/grok/classify to expose classification to the client.
- Wire classifier into GrokService: Grok now calls the classifier when a reply tag is neutral and accepts a resolvedUserMood override from requests.
- Replace client-side heuristic/regEx hostile inference: remove inferHostileUserTone and simplify moodSignal resolution.
- Adjust mood state machine to require 2 tags for romantic (and keep other moods at 2), update related APIs (buildMoodSignal/commitTurn signatures).
- Add turnPlanner.computeResponseMood and use it to decide response tone when approaching/cooling.
- Update responseHandler to call the classifier client-side, include resolvedUserMood in Grok payloads, and simplify multi-step logic.
- Update prompt generation and mood guidelines (prompts/moodPersonalities.ts, promptGenerator.ts) to emphasize prompt-driven tagging and approaching behavior.
- Add LLM evaluation for tagging (src/app/evals/moodTagging.eval.ts) and new tests for classifier and turn planner; update many tests and evals to reflect the new 2-tag thresholds and behavior.
- Update README and package.json (new test:tags script) to document the two-step detection flow and testing commands.

Overall motivation: move mood detection off brittle client-side heuristics into a consistent, prompt-driven two-step flow (Grok reply tag + fallback classifier) and simplify state resolution while updating tests and docs accordingly.