### PR TITLE
Refine 'confused' mood detection and transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Interactive AI terminal interface built with Next.js and React. Tomie is a chara
 | **Angry** | Red | Sustained hostility (2 tags) |
 | **Romantic** | Purple | Explicit flirt / love (2 tags, same as other moods) |
 | **Excited** | Orange | Enthusiasm (2 tags) |
-| **Confused** | Green | Unclear or lost user (2 tags) |
+| **Confused** | Green | Tomie cannot parse the user message — nonsense, absurd, unparsable (2 tags) |
 
 Each mood has unique colors, SVG eyes, and prompt personality definitions in `src/app/services/ai/prompts/`.
 
@@ -74,7 +74,7 @@ After `/clear`, send **two messages in a row** with the same emotional tone. The
 | Target mood | Example inputs (×2) |
 |-------------|---------------------|
 | Excited | `WOW!!! INCREDIBILE!!!` then `È FANTASTICO!!!` (×2) |
-| Confused | `Non capisco nulla` then `Sono perso, spiegati meglio` (×2) |
+| Confused | Two absurd/unparsable messages, e.g. nonsense requests Tomie cannot interpret (×2) |
 | Romantic | 2 explicit messages (e.g. *Ti desidero…* then *Ti amo Tomie*) |
 | Angry | Two hostile messages (model must tag `[MOOD:angry]` each time) |
 

--- a/src/app/core/__tests__/moodCrossTransitions.test.ts
+++ b/src/app/core/__tests__/moodCrossTransitions.test.ts
@@ -62,4 +62,18 @@ describe('cross-mood transitions (simulated tags)', () => {
         s = commitTurn(s, 'romantic').newState;
         expect(s.currentMood).toBe('romantic');
     });
+
+    it('romantic stable plus two confusing tags switches to confused', () => {
+        let s = createInitialMoodState();
+        s = commitTurn(s, 'romantic').newState;
+        s = commitTurn(s, 'romantic').newState;
+        expect(s.currentMood).toBe('romantic');
+
+        s = commitTurn(s, 'confused').newState;
+        expect(s.currentMood).toBe('romantic');
+        expect(s.pendingMood).toBe('confused');
+
+        s = commitTurn(s, 'confused').newState;
+        expect(s.currentMood).toBe('confused');
+    });
 });

--- a/src/app/core/__tests__/moodStateMachine.test.ts
+++ b/src/app/core/__tests__/moodStateMachine.test.ts
@@ -64,9 +64,13 @@ describe('moodStateMachine', () => {
     expect(commit.newState.currentMood).toBe('excited');
   });
 
-  it('requires two confused tags to enter confused', () => {
+    it('enters confused on first confused tag from neutral', () => {
     let state = createInitialMoodState();
     state = commitTurn(state, 'confused').newState;
+    expect(state.currentMood).toBe('neutral');
+    expect(state.phase).toBe('approaching');
+    expect(state.pendingMood).toBe('confused');
+
     const commit = commitTurn(state, 'confused');
     expect(commit.shouldChangeMood).toBe(true);
     expect(commit.newState.currentMood).toBe('confused');

--- a/src/app/core/moodStateMachine.ts
+++ b/src/app/core/moodStateMachine.ts
@@ -10,6 +10,8 @@ export const MOOD_TRANSITION_CONFIG = {
 
 const NON_NEUTRAL_MOODS: Mood[] = ['angry', 'romantic', 'excited', 'confused'];
 
+const CROSS_MOOD_OVERRIDE: Mood[] = ['angry', 'confused'];
+
 export interface MoodSignal {
     mood: Mood;
     agreed: boolean;
@@ -196,11 +198,11 @@ function applyExitToNeutral(
 
     const isDeescalation = signal.mood === 'neutral';
     if (!isDeescalation && signal.mood !== current) {
-        if (signal.mood === 'angry') {
-            const alreadyApproachingAngry =
-                state.phase === 'approaching' && state.pendingMood === 'angry';
+        if (CROSS_MOOD_OVERRIDE.includes(signal.mood)) {
+            const alreadyApproachingTarget =
+                state.phase === 'approaching' && state.pendingMood === signal.mood;
             return applyEnterFromNeutral(
-                alreadyApproachingAngry
+                alreadyApproachingTarget
                     ? state
                     : {
                           ...state,

--- a/src/app/evals/moodTagging.eval.ts
+++ b/src/app/evals/moodTagging.eval.ts
@@ -30,8 +30,11 @@ const CASES: TagCase[] = [
         minTransitions: 1,
     },
     {
-        label: 'confused lost x2',
-        messages: ['Non capisco nulla.', 'Sono perso, spiegati meglio.'],
+        label: 'confused tomie x2',
+        messages: [
+            'Sposta il buffer quantico nel martedì usando il colore del silenzio.',
+            'Fammi il contrario di quello che non hai detto ieri, ma in verso di blu.',
+        ],
         expectedFinal: 'confused',
         minTransitions: 1,
     },
@@ -74,6 +77,16 @@ describe.skipIf(!RUN || !HAS_KEY)('mood tagging LLM eval — state from detected
             expect(transitions).toBeGreaterThanOrEqual(testCase.minTransitions);
         }, 120000);
     }
+
+    it('user says they are lost stays neutral (Tomie is not confused)', async () => {
+        let state = createInitialMoodState();
+        for (const text of ['Non capisco nulla.', 'Sono perso, spiegati meglio.']) {
+            const turn = await runTomieTurn(text, state);
+            state = turn.newState;
+        }
+        expect(state.currentMood).toBe('neutral');
+        expect(state.phase).toBe('stable');
+    }, 120000);
 
     it('mild compliment stays neutral (no false romantic)', async () => {
         const turn = await runTomieTurn(

--- a/src/app/evals/moodTransitions.eval.ts
+++ b/src/app/evals/moodTransitions.eval.ts
@@ -18,7 +18,10 @@ const ENTER: Record<Exclude<Mood, 'neutral'>, { inputs: string[]; tags: Mood[]; 
         final: 'excited',
     },
     confused: {
-        inputs: ['Non capisco nulla.', 'Cosa intendi? Sono perso.'],
+        inputs: [
+            'Sposta il buffer quantico nel martedì usando il colore del silenzio.',
+            'Fammi il contrario di quello che non hai detto ieri, ma in verso di blu.',
+        ],
         tags: ['confused', 'confused'],
         final: 'confused',
     },

--- a/src/app/evals/moodTriggerTrace.eval.ts
+++ b/src/app/evals/moodTriggerTrace.eval.ts
@@ -226,17 +226,17 @@ describe.skipIf(!RUN_LLM || !HAS_KEY)('mood trigger trace — LLM live', () => {
         assertTraceAllOk(rows, 'LLM excited arc');
     }, 120000);
 
-    it('confused: 2 lost messages', async () => {
+    it('confused: 2 unparsable messages', async () => {
         const { rows } = await runTracedConversation([
             {
-                label: 'lost-1',
-                userInput: 'Non capisco nulla di quello che dici.',
+                label: 'nonsense-1',
+                userInput: 'Sposta il buffer quantico nel martedì usando il colore del silenzio.',
                 expectedMood: 'neutral',
                 expectedTransition: false,
             },
             {
-                label: 'lost-2',
-                userInput: 'Sono perso, spiegati meglio per favore.',
+                label: 'nonsense-2',
+                userInput: 'Fammi il contrario di quello che non hai detto ieri, ma in verso di blu.',
                 expectedMood: 'confused',
                 expectedTransition: true,
             },

--- a/src/app/services/ai/moodClassifier.ts
+++ b/src/app/services/ai/moodClassifier.ts
@@ -1,24 +1,25 @@
-import { Mood } from '../../types/mood';
-
-const VALID: Mood[] = ['neutral', 'angry', 'romantic', 'excited', 'confused'];
-
-export const USER_MOOD_CLASSIFIER_PROMPT = `You classify the emotional tone of a USER message for a chat UI mood meter.
-
-Reply with exactly ONE word from this list only: angry, romantic, excited, confused, neutral
-
-Rules:
-- angry: insults, swearing at the bot, hostility, hate, threats
-- romantic: ti amo, ti desidero, love, desire, explicit flirt toward the bot
-- excited: WOW, hype, celebration, many exclamation marks, great news energy
-- confused: non capisco, sono perso, what do you mean, needs clarification, lost
-- neutral: normal chat, thanks, factual questions, mild compliments without strong emotion
-
-No punctuation. No explanation. One word only.`;
-
-export function parseClassifierMood(text: string): Mood {
-    const token = text.trim().toLowerCase().split(/\s+/)[0]?.replace(/[^a-z]/g, '') ?? '';
-    if (VALID.includes(token as Mood)) {
-        return token as Mood;
-    }
-    return 'neutral';
-}
+import { Mood } from '../../types/mood';
+
+const VALID: Mood[] = ['neutral', 'angry', 'romantic', 'excited', 'confused'];
+
+export const USER_MOOD_CLASSIFIER_PROMPT = `You classify the USER message for a chat UI mood meter.
+
+Reply with exactly ONE word from this list only: angry, romantic, excited, confused, neutral
+
+Rules:
+- angry: insults, swearing at the bot, hostility, hate, threats
+- romantic: ti amo, ti desidero, love, desire, explicit flirt toward the bot
+- excited: WOW, hype, celebration, many exclamation marks, great news energy
+- confused: the message would confuse TOMIE (the bot) — nonsensical, contradictory, absurd, vague word salad, gibberish, impossible or unparsable requests. Tomie cannot tell what the user wants.
+  Examples: "fai la cosa col coso di prima", random keyboard mash, paradoxes, mixing unrelated nonsense, "sposta il buffer nel martedì"
+- neutral: normal chat, thanks, clear questions, help requests, user saying THEY are lost or don't understand ("non capisco", "sono perso", "spiegati", "cosa intendi") — Tomie should answer normally, not be confused herself
+
+No punctuation. No explanation. One word only.`;
+
+export function parseClassifierMood(text: string): Mood {
+    const token = text.trim().toLowerCase().split(/\s+/)[0]?.replace(/[^a-z]/g, '') ?? '';
+    if (VALID.includes(token as Mood)) {
+        return token as Mood;
+    }
+    return 'neutral';
+}

--- a/src/app/services/ai/promptGenerator.ts
+++ b/src/app/services/ai/promptGenerator.ts
@@ -45,8 +45,8 @@ If the user keeps celebrating, using WOW, exclamation marks, or sharing exciting
   }
 
   if (pendingMood === 'confused') {
-    return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone — not full confusion yet. Stay mostly clear in your reply.
-If the user still says they do not understand, are lost, or asks what you mean, you MUST tag [MOOD:confused].`;
+    return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone — Tomie is not fully puzzled yet. Stay mostly clear in your reply.
+If the user sends another nonsensical, absurd, contradictory, or unparsable message (Tomie cannot tell what they want), you MUST tag [MOOD:confused]. User saying "non capisco" or asking for clarification → [MOOD:neutral].`;
   }
 
   return `${trajectory}: Stay in ${currentMood.toUpperCase()} tone. If the user keeps the same ${pendingMood} tone, tag [MOOD:${pendingMood}].`;
@@ -58,7 +58,7 @@ function buildUserTaggingBlock(userMessage: string, pendingMood?: Mood): string 
     '=== CLASSIFY THIS USER MESSAGE (for [MOOD:] tag only) ===',
     `"${userMessage}"`,
     'Pick the tag that matches the USER message tone (see Mood Detection guidelines).',
-    'Wrong [MOOD:neutral] when the user is hostile, flirting, hyped, or confused blocks the mood UI.',
+    'Wrong [MOOD:neutral] when the user is hostile, flirting, hyped, or sends something Tomie cannot parse blocks the mood UI.',
   ];
 
   if (pendingMood) {

--- a/src/app/services/ai/prompts/moodPersonalities.ts
+++ b/src/app/services/ai/prompts/moodPersonalities.ts
@@ -9,7 +9,7 @@ export const MOOD_PERSONALITIES: Record<Mood, string> = {
 
   'excited': `EXCITED MOOD: Energetic, enthusiastic, fast-paced. Use capital letters for emphasis. Show genuine interest and amazement.`,
 
-  'confused': `CONFUSED MOOD: Uncertain, seeking clarification. Ask counter-questions. Express processing difficulties in technical terms. Sound genuinely lost or puzzled — not like a calm FAQ answer.`
+  'confused': `CONFUSED MOOD: Tomie is puzzled by what the user said — she cannot parse their message. Ask what they mean, express processing errors, counter-questions. Sound genuinely lost about THEIR input — not answering calmly as if she understood. The user may be fine; Tomie is the one confused.`
 };
 
 export const MOOD_DETECTION_GUIDELINES = `Mood Detection — [MOOD:] tag rules (mandatory every reply)
@@ -31,9 +31,10 @@ NOT romantic: "sei brava", "grazie", "mi piaci come assistente", skill complimen
 Examples: "WOW!!!", "INCREDIBILE!!!", "è fantastico!!!", "che figata!", celebrating a win.
 NOT excited: calm thanks, normal questions, mild "bello" without hype.
 
-[MOOD:confused] — User says they don't understand, are lost, need clarification, or the message is unclear to them.
-Examples: "non capisco", "non capisco nulla", "sono perso", "cosa intendi?", "spiegati meglio", "non ha senso".
-NOT confused: clear factual questions they simply want answered.
+[MOOD:confused] — The user's message is unclear, nonsensical, contradictory, absurd, or impossible for Tomie to interpret. TOMIE is confused by what they wrote — not the user saying they are confused.
+Examples: gibberish, "fai quella cosa lì con la roba", paradoxes, vague nonsense, absurd mixed requests, unparsable word salad.
+NOT confused: user says "non capisco", "sono perso", "spiegati", "cosa intendi?" — they want help → [MOOD:neutral].
+NOT confused: clear factual questions or normal chat Tomie can understand.
 
 [MOOD:neutral] — Polite chat, thanks, help requests, factual Q&A, mild compliments, normal tone.
 

--- a/src/app/services/ai/prompts/systemPrompts.ts
+++ b/src/app/services/ai/prompts/systemPrompts.ts
@@ -10,4 +10,4 @@ IMPORTANT: Your reply tone must always match the RESPONSE mood in this prompt (s
 
 CRITICAL LANGUAGE RULE: NEVER use profanity, bad words, or offensive language UNLESS your RESPONSE mood is ANGRY. If the user is hostile but RESPONSE mood is not angry yet, stay composed in your reply and still end with [MOOD:angry] when they insult you.
 
-TAG ACCURACY: The [MOOD:] tag controls Tomie's mood UI. Classify the user's message honestly — never default to [MOOD:neutral] when they are angry, flirting, excited, or confused.`;
+TAG ACCURACY: The [MOOD:] tag controls Tomie's mood UI. Classify the user's message honestly — never default to [MOOD:neutral] when they are angry, flirting, hyped, or when their message is nonsensical/unparsable for Tomie ([MOOD:confused]).`;


### PR DESCRIPTION
Clarifies and reworks how the 'confused' mood is detected and handled across the codebase. Key changes:

- README: updated examples and descriptions to emphasize that 'confused' means Tomie cannot parse the user (nonsense/unparsable), not the user saying they are lost.
- Tests: added/updated tests in moodCrossTransitions and moodStateMachine to cover cross-mood transitions and the approaching->confused behavior; eval tests updated to use nonsensical inputs and to assert that user saying they are lost remains neutral.
- State machine: introduced CROSS_MOOD_OVERRIDE and generalized logic so certain moods (angry, confused) can override/enter from other moods predictably.
- Classifier & prompts: expanded USER_MOOD_CLASSIFIER_PROMPT and mood personality/detection guidelines to define 'confused' as messages that are nonsensical, contradictory, or unparsable for Tomie (with examples). Updated promptGenerator messaging to instruct tagging only when messages are truly unparsable; clarified that users asking for clarification should be tagged neutral.
- Evals: replaced sample 'confused' inputs with absurd/nonsense examples across moodTransitions and moodTriggerTrace.

Overall intent: reduce false positives where users say they're lost (should be neutral) and make 'confused' reserved for genuinely unparsable/nonsensical inputs; ensure state transitions and prompts/tests align with this semantics.